### PR TITLE
Fix Levels property access and document nested effect structures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,25 @@ För ScriptUI-paneler, använd `@type script` istället för `expression`.
 - Referera alltid till effektparametrar med **namn**, inte index: `effect("Fractal Noise")("Contrast")` – aldrig `effect("Fractal Noise")(4)`. Index kan förskjutas om effekter läggs till eller AE uppdateras.
 - Använd JavaScript expression engine (standard i AE 2026), inte Legacy ExtendScript engine.
 
+**I ScriptUI-scripts** (ExtendScript .jsx-filer):
+- Använd **match names** för att referera till effekter och parametrar, t.ex. `layer.property("ADBE Effect Parade").property("ADBE Gaussian Blur")`. Match names är språkoberoende och fungerar oavsett vilket språk AE är inställt på.
+- Använd aldrig numeriska index för att referera till effektparametrar.
+- Använd aldrig display names som enda åtkomstmetod – de är språkberoende och misslyckas på icke-engelska AE-installationer.
+
+**Nästlade effektstrukturer – VIKTIGT:**
+
+Vissa AE-effekter har **nästlade property-grupper** där parametrarna inte sitter direkt under effekten utan i sub-grupper. Den generiska `sp()`-funktionen (som söker display names) är **inte tillförlitlig** för sådana effekter och kan sätta fel parameter eller inte sätta något alls.
+
+- **`ADBE Levels2`** (Levels / Individual Controls) – parametrarna sitter i per-kanal sub-grupper (Master, Red, Green, Blue, Alpha). `sp(fx, "Output Black", val)` hittar inte parametern på toppnivån.
+- **`ADBE Fractal Noise`** – Transform-parametrar sitter i en `Transform`-sub-grupp, Evolution Options i en separat grupp.
+
+**Regel:** När en effekt har känd komplex struktur, skriv en **dedikerad setter-funktion** (som `setLevels()` och `fnSp()` i film_damage_suite.jsx) som explicit provar:
+1. Match names direkt på effekten
+2. Display names direkt på effekten (engelska fallback)
+3. Display names i varje sub-grupp (fallback för nästlad struktur)
+
+Använd aldrig den generiska `sp()` för Levels eller andra effekter med känd nästlad struktur.
+
 ---
 
 ## README.md

--- a/scripts/film_damage_suite.jsx
+++ b/scripts/film_damage_suite.jsx
@@ -29,7 +29,7 @@
  *  Effektparameter-namn är engelska display names och kan misslyckas på
  *  icke-engelska AE-installationer.
  *
- *  Levels Input Black 2500 / Input White 30000 är 16-bitsvärden.
+ *  Levels Output Black 2500 / Output White 30000 är 16-bitsvärden.
  *  Projektet sätts till 16 bpc automatiskt av panelen.
  */
 (function filmDamagePanel(thisObj) {
@@ -126,6 +126,42 @@
                 } catch (e2) {}
             }
         } catch (e) {}
+    }
+
+    // Levels-specifik setter – ADBE Levels har platt struktur, ADBE Levels2 har
+    // nästlade kanal-sub-grupper. sp() hittar inte Output Black/White i nästlad
+    // struktur. Provar match names → display names direkt → sub-grupp-sökning.
+    function setLevels(fx, outBlack, outWhite) {
+        if (!fx) return;
+        // Match names (språkoberoende) – ADBE Levels respektive ADBE Levels2
+        var pairs = [
+            ["ADBE Levels-0006",  "ADBE Levels-0007"],
+            ["ADBE Levels2-0006", "ADBE Levels2-0007"]
+        ];
+        for (var n = 0; n < pairs.length; n++) {
+            try {
+                fx.property(pairs[n][0]).setValue(outBlack);
+                fx.property(pairs[n][1]).setValue(outWhite);
+                return;
+            } catch(e) {}
+        }
+        // Display names direkt (fungerar vid engelska AE-installationer)
+        try {
+            fx.property("Output Black").setValue(outBlack);
+            fx.property("Output White").setValue(outWhite);
+            return;
+        } catch(e) {}
+        // Fallback: sök i sub-grupper (ADBE Levels2 nästlar per kanal)
+        try {
+            for (var i = 1; i <= fx.numProperties; i++) {
+                var g = fx.property(i);
+                try {
+                    g.property("Output Black").setValue(outBlack);
+                    g.property("Output White").setValue(outWhite);
+                    return;
+                } catch(e2) {}
+            }
+        } catch(e) {}
     }
 
     // Fractal Noise setter – söker explicit via kända sub-grupper:
@@ -381,7 +417,7 @@
     // CHANNEL MIXER: Blue-Green 50, Blue-Blue 50
     // LUMETRI COLOR: Look + Highlight Tint sätts manuellt i Effect Controls
     // CC VIGNETTE: Amount 50
-    // LEVELS: Input Black 2500, Input White 30000 (16-bpc-värden)
+    // LEVELS: Output Black 2500, Output White 30000 (16-bpc-värden)
     function createColorCorrection(comp) {
         try { app.project.bitsPerChannel = 16; } catch (e) {}
         var l = mkAdj(comp, N.COLOR_CORRECTION);
@@ -408,12 +444,10 @@
         var vfx = addFX(l, "CC Vignette", "CC Vignette");
         sp(vfx, "Amount", 50);
 
-        var lvl = addFX(l, "ADBE Levels2", "Levels");
-        if (!lvl) lvl = addFX(l, "ADBE Levels", "Levels");
-        if (lvl) {
-            sp(lvl, "Output Black", 2500);
-            sp(lvl, "Output White", 30000);
-        }
+        // ADBE Levels (platt struktur) prövas före ADBE Levels2 (nästlad kanal-struktur)
+        var lvl = addFX(l, "ADBE Levels", "Levels");
+        if (!lvl) lvl = addFX(l, "ADBE Levels2", "Levels");
+        setLevels(lvl, 2500, 30000);
     }
 
     // ── 9. LIGHT LEAKS ────────────────────────────────────────────────────────


### PR DESCRIPTION
- Add dedicated setLevels() function that tries match names, then display names directly, then sub-group search – handles both ADBE Levels (flat) and ADBE Levels2 (nested per-channel groups)
- Swap addFX order to try ADBE Levels before ADBE Levels2 (simpler structure)
- Fix misleading header comments: Output Black/White, not Input Black/White
- Update CLAUDE.md: document which effects have nested property structures, explain why sp() is unreliable for them, and require dedicated setters

https://claude.ai/code/session_01Fi4M8gUQSpk2nu7upuyzdh