### PR TITLE
Remove unverified Levels match names causing wrong property access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,11 +98,13 @@ Vissa AE-effekter har **nästlade property-grupper** där parametrarna inte sitt
 - **`ADBE Fractal Noise`** – Transform-parametrar sitter i en `Transform`-sub-grupp, Evolution Options i en separat grupp.
 
 **Regel:** När en effekt har känd komplex struktur, skriv en **dedikerad setter-funktion** (som `setLevels()` och `fnSp()` i film_damage_suite.jsx) som explicit provar:
-1. Match names direkt på effekten
+1. Match names direkt på effekten – **endast om de är verifierade i AE SDK eller testad i AE**. Använd aldrig gissade match names; om de råkar träffa fel property kan värdet bli extremt felaktigt (t.ex. 2500 → 81 920 000 om en intern float-property träffas).
 2. Display names direkt på effekten (engelska fallback)
 3. Display names i varje sub-grupp (fallback för nästlad struktur)
 
 Använd aldrig den generiska `sp()` för Levels eller andra effekter med känd nästlad struktur.
+
+**Match names för Levels Output-parametrar är ej verifierade** – `setLevels()` i film_damage_suite.jsx använder därför enbart display names och sub-grupp-sökning.
 
 ---
 

--- a/scripts/film_damage_suite.jsx
+++ b/scripts/film_damage_suite.jsx
@@ -130,21 +130,10 @@
 
     // Levels-specifik setter – ADBE Levels har platt struktur, ADBE Levels2 har
     // nästlade kanal-sub-grupper. sp() hittar inte Output Black/White i nästlad
-    // struktur. Provar match names → display names direkt → sub-grupp-sökning.
+    // struktur. Match names för Levels Output-parametrar är ej verifierade och
+    // används därför inte – söker display names direkt eller i sub-grupper.
     function setLevels(fx, outBlack, outWhite) {
         if (!fx) return;
-        // Match names (språkoberoende) – ADBE Levels respektive ADBE Levels2
-        var pairs = [
-            ["ADBE Levels-0006",  "ADBE Levels-0007"],
-            ["ADBE Levels2-0006", "ADBE Levels2-0007"]
-        ];
-        for (var n = 0; n < pairs.length; n++) {
-            try {
-                fx.property(pairs[n][0]).setValue(outBlack);
-                fx.property(pairs[n][1]).setValue(outWhite);
-                return;
-            } catch(e) {}
-        }
         // Display names direkt (fungerar vid engelska AE-installationer)
         try {
             fx.property("Output Black").setValue(outBlack);


### PR DESCRIPTION
ADBE Levels-0006 hit an internal HDR float property, not Output Black, causing setValue(2500) to display as 81,920,000 (2500 × 32768).

setLevels() now goes directly to display name search ("Output Black" / "Output White") and sub-group fallback instead of guessing match names. Updated CLAUDE.md: warn that unverified match names must never be used.

https://claude.ai/code/session_01Fi4M8gUQSpk2nu7upuyzdh