### PR TITLE
Fix Levels setValue unit: normalize 16-bit values to 0.0–1.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,8 @@ Använd aldrig den generiska `sp()` för Levels eller andra effekter med känd n
 
 **Match names för Levels Output-parametrar är ej verifierade** – `setLevels()` i film_damage_suite.jsx använder därför enbart display names och sub-grupp-sökning.
 
+**setValue()-enheter för Levels – VIKTIGT:** AE:s Levels-properties lagrar värden normaliserat (0.0–1.0) internt. UI:t visar värdena skalade till projektets bitdjup (×32 768 för 16 bpc). Att skicka in ett råvärde som 2500 (16-bit-enhet) utan normalisering resulterar i 2500 × 32 768 = 81 920 000 i UI:t. Normalisera alltid: `setValue(value16bit / 32768)`.
+
 ---
 
 ## README.md

--- a/scripts/film_damage_suite.jsx
+++ b/scripts/film_damage_suite.jsx
@@ -128,16 +128,20 @@
         } catch (e) {}
     }
 
-    // Levels-specifik setter – ADBE Levels har platt struktur, ADBE Levels2 har
-    // nästlade kanal-sub-grupper. sp() hittar inte Output Black/White i nästlad
-    // struktur. Match names för Levels Output-parametrar är ej verifierade och
-    // används därför inte – söker display names direkt eller i sub-grupper.
-    function setLevels(fx, outBlack, outWhite) {
+    // Levels-specifik setter – AE:s Levels-properties använder normaliserade
+    // 0.0–1.0-värden via setValue(). UI visar värdena skalade till projektets
+    // bitdjup: ×32 768 för 16 bpc. Parametrarna tas emot som 16-bit-värden
+    // (0–32 768) och normaliseras internt.
+    // ADBE Levels har platt struktur, ADBE Levels2 har nästlade kanal-sub-grupper.
+    // Match names för Output-parametrarna är ej verifierade och används inte.
+    function setLevels(fx, outBlack16, outWhite16) {
         if (!fx) return;
+        var black = outBlack16 / 32768;
+        var white = outWhite16 / 32768;
         // Display names direkt (fungerar vid engelska AE-installationer)
         try {
-            fx.property("Output Black").setValue(outBlack);
-            fx.property("Output White").setValue(outWhite);
+            fx.property("Output Black").setValue(black);
+            fx.property("Output White").setValue(white);
             return;
         } catch(e) {}
         // Fallback: sök i sub-grupper (ADBE Levels2 nästlar per kanal)
@@ -145,8 +149,8 @@
             for (var i = 1; i <= fx.numProperties; i++) {
                 var g = fx.property(i);
                 try {
-                    g.property("Output Black").setValue(outBlack);
-                    g.property("Output White").setValue(outWhite);
+                    g.property("Output Black").setValue(black);
+                    g.property("Output White").setValue(white);
                     return;
                 } catch(e2) {}
             }


### PR DESCRIPTION
AE Levels properties use normalized 0.0–1.0 values internally; the UI displays them scaled by ×32768 for 16-bpc projects. Passing raw 16-bit values (e.g. 2500) caused setValue(2500) → 81,920,000 in the UI.

setLevels() now divides by 32768 before calling setValue(), so outBlack=2500 → setValue(0.0763) → displays as 2500 in 16-bpc.

Updated CLAUDE.md with the normalization rule.

https://claude.ai/code/session_01Fi4M8gUQSpk2nu7upuyzdh