### PR TITLE
Add debug_lumetri.jsx to dump Lumetri Color property tree

### DIFF
--- a/scripts/debug_lumetri.jsx
+++ b/scripts/debug_lumetri.jsx
@@ -1,0 +1,73 @@
+/**
+ * @name        Debug Lumetri Color Structure
+ * @category    utility
+ * @type        script
+ * @description Dumpar hela Lumetri Color-effektens property-träd:
+ *              matchName, displayName och nuvarande värde för alla
+ *              properties och sub-grupper (3 nivåer djupt).
+ * @usage       1. Lägg till Lumetri Color på ett lager.
+ *              2. Välj lagret.
+ *              3. Kör via File → Scripts → Run Script File...
+ * @ae-version  2026
+ */
+(function () {
+    var comp = app.project.activeItem;
+    if (!comp || !(comp instanceof CompItem)) {
+        alert("Öppna en komp och välj ett lager med Lumetri Color-effekt.");
+        return;
+    }
+
+    var layer = comp.selectedLayers.length > 0 ? comp.selectedLayers[0] : null;
+    if (!layer) { alert("Välj ett lager med Lumetri Color-effekt."); return; }
+
+    // Hitta Lumetri Color
+    var fx = null;
+    var eff = layer.property("Effects");
+    for (var e = 1; e <= eff.numProperties; e++) {
+        if (eff.property(e).matchName === "ADBE Lumetri") { fx = eff.property(e); break; }
+    }
+    if (!fx) { alert("Ingen Lumetri Color-effekt hittades på lagret."); return; }
+
+    function readVal(prop) {
+        try {
+            var v = prop.value;
+            if (v && v.length !== undefined && v.length <= 4) return "[" + v + "]";
+            return String(v);
+        } catch(e) { return "–"; }
+    }
+
+    function dumpGroup(prop, indent) {
+        var out = "";
+        var n = 0;
+        try { n = prop.numProperties; } catch(e) { return out; }
+        for (var i = 1; i <= n; i++) {
+            var p;
+            try { p = prop.property(i); } catch(e) { continue; }
+            var hasChildren = false;
+            try { hasChildren = p.numProperties > 0; } catch(e) {}
+
+            out += indent + "[" + i + "] \"" + p.name + "\"";
+            out += "  mn=" + p.matchName;
+            if (!hasChildren) out += "  val=" + readVal(p);
+            out += "\n";
+
+            if (hasChildren && indent.length < 12) {
+                out += dumpGroup(p, indent + "    ");
+            }
+        }
+        return out;
+    }
+
+    var out = "=== LUMETRI COLOR – property-träd ===\n";
+    out += "Effekt: \"" + fx.name + "\"  matchName=" + fx.matchName + "\n";
+    out += "numProperties: " + fx.numProperties + "\n\n";
+    out += dumpGroup(fx, "  ");
+
+    // Dela upp i två alerts om texten är lång
+    if (out.length > 2000) {
+        alert(out.substring(0, 2000) + "\n\n[fortsättning i nästa alert...]");
+        alert(out.substring(2000));
+    } else {
+        alert(out);
+    }
+}());


### PR DESCRIPTION
Iterates all properties and sub-groups (3 levels deep) and prints matchName, displayName and current value. Used to verify which Creative section properties (Look, Highlight Tint etc.) are accessible via scripting.

https://claude.ai/code/session_01Fi4M8gUQSpk2nu7upuyzdh